### PR TITLE
DP3: bump dnspython 2.0.0 to 2.6.1

### DIFF
--- a/dp3_server/requirements.txt
+++ b/dp3_server/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/CESNET/dp3.git#egg=dp-cubed
 requests
 setuptools>=57.0.0
-dnspython~=2.0.0
+dnspython~=2.6.1


### PR DESCRIPTION
Fixes potential DoS via the Tudoor mechanism in eventlet and dnspython.

https://www.dnspython.org/news/2.6.1/