### PR TITLE
feat(frontend): add new summary page for IP subnets

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "dayjs": "^1.11.13",
         "floating-vue": "^5.2.2",
         "font-awesome": "^4.7.0",
+        "ipaddr.js": "^2.2.0",
         "netmask": "^2.0.2",
         "pinia": "^3.0.1",
         "vue": "^3.5.13",
@@ -3365,6 +3366,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "dayjs": "^1.11.13",
         "floating-vue": "^5.2.2",
         "font-awesome": "^4.7.0",
+        "netmask": "^2.0.2",
         "pinia": "^3.0.1",
         "vue": "^3.5.13",
         "vue-axios": "^3.5.2",
@@ -3809,6 +3810,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "dayjs": "^1.11.13",
     "floating-vue": "^5.2.2",
     "font-awesome": "^4.7.0",
+    "ipaddr.js": "^2.2.0",
     "netmask": "^2.0.2",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "dayjs": "^1.11.13",
     "floating-vue": "^5.2.2",
     "font-awesome": "^4.7.0",
+    "netmask": "^2.0.2",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",
     "vue-axios": "^3.5.2",

--- a/frontend/src/components/ActivityTimeline.vue
+++ b/frontend/src/components/ActivityTimeline.vue
@@ -137,6 +137,23 @@ const chartData = computed(() => {
     },
   )
 
+  // Round number of packets, flows, and bytes
+  // Only applied to values >= 10. This is to avoid confusion, because user
+  // doesn't expect to see 102.34 bytes transferred. For smaller values, it
+  // might be better to show the exact value.
+  // (This is due to redistribution of long flows into smaller time windows.)
+  for (const dp of data) {
+    if (dp.packets >= 10) {
+      dp.packets = Math.round(dp.packets)
+    }
+    if (dp.flows >= 10) {
+      dp.flows = Math.round(dp.flows)
+    }
+    if (dp.bytes >= 10) {
+      dp.bytes = Math.round(dp.bytes)
+    }
+  }
+
   return {
     datasets: [
       {

--- a/frontend/src/components/IPSubnetRedirectPicker.vue
+++ b/frontend/src/components/IPSubnetRedirectPicker.vue
@@ -1,0 +1,144 @@
+<!--
+IP subnet picker with redirect
+
+This component is used to pick an IP subnet and redirect to the appropriate route.
+It uses the ipaddr.js library to validate the IP address and prefix length.
+-->
+
+<script setup>
+import { computed, ref } from 'vue'
+import ipaddr from 'ipaddr.js'
+
+const props = defineProps({
+  /**
+   * Whether to use IPv4 or IPv6
+   * @type {boolean}
+   * @default true
+   */
+  isIPv4: {
+    type: Boolean,
+    default: true,
+  },
+
+  /**
+   * The route name to use for the redirect
+   * @type {string}
+   */
+  routeName: {
+    type: String,
+    required: true,
+  },
+
+  /**
+   * The text to display on the button
+   * @type {string}
+   * @default 'View'
+   */
+  buttonText: {
+    type: String,
+    default: 'View',
+  },
+
+  /**
+   * The icon to display on the button
+   * @type {string}
+   * @default 'fa fa-chevron-right'
+   */
+  buttonIcon: {
+    type: String,
+    default: 'fa fa-chevron-right',
+  },
+
+  /**
+   * The minimum prefix length for the subnet
+   * @type {number}
+   * @default 16
+   */
+  minPrefix: {
+    type: Number,
+    default: 16,
+  },
+
+  /**
+   * The maximum prefix length for the subnet
+   * @type {number}
+   * @default 32
+   */
+  maxPrefix: {
+    type: Number,
+    default: 32,
+  },
+
+  /**
+   * The default prefix length for the subnet
+   * @type {number}
+   * @default 24
+   */
+  defaultPrefix: {
+    type: Number,
+    default: 24,
+  },
+})
+
+const ip = ref(null)
+const prefix = ref(props.defaultPrefix)
+
+/**
+ * IP address validator
+ */
+const ipValid = computed(() => {
+  if (props.isIPv4) {
+    // `ipaddr.IPv4.isValid()` allows even '1.2' as valid
+    return ipaddr.IPv4.isValidFourPartDecimal(ip.value)
+  } else {
+    return ipaddr.IPv6.isValid(ip.value)
+  }
+})
+
+/**
+ * Possible prefixes
+ */
+const prefixes = computed(() => {
+  return Array(props.maxPrefix - props.minPrefix + 1)
+    .fill()
+    .map((_, i) => props.minPrefix + i)
+})
+</script>
+
+<template>
+  <div class="row">
+    <div class="col-md-8">
+      <div class="input-group my-2">
+        <div class="input-group-text">IP</div>
+        <input
+          v-model="ip"
+          type="text"
+          class="form-control"
+          :class="{ 'is-invalid': ip && !ipValid }"
+          :placeholder="props.isIPv4 ? '1.2.3.4' : 'fe80::1'"
+        />
+        <div class="input-group-text">/</div>
+        <select v-model="prefix" class="form-select">
+          <option v-for="p in prefixes" v-bind:key="p">{{ p }}</option>
+        </select>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <component
+        :is="!ip || !ipValid ? 'div' : 'router-link'"
+        :to="{
+          name: routeName,
+          params: {
+            ip: ip,
+            prefix: prefix,
+          },
+        }"
+        class="btn btn-primary my-2 w-100"
+        :class="{ disabled: !ip || !ipValid }"
+      >
+        {{ buttonText }}
+        <i :class="buttonIcon"></i>
+      </component>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -1,13 +1,48 @@
 <script setup>
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
+
+const route = useRoute()
 </script>
 
 <template>
-  <nav class="navbar bg-body-tertiary">
+  <nav class="navbar bg-body-tertiary navbar-expand-lg">
     <div class="container">
-      <RouterLink :to="{ name: 'home' }" class="navbar-brand">
-        <img src="@/assets/logo.svg" alt="PANDDA" class="logo" />
-      </RouterLink>
+      <div class="navbar-brand">
+        <RouterLink :to="{ name: 'home' }" class="navbar-brand">
+          <img src="@/assets/logo.svg" alt="PANDDA" class="logo" />
+        </RouterLink>
+      </div>
+      <button
+        class="navbar-toggler"
+        data-bs-toggle="collapse"
+        data-bs-target="#navbarSupportedContent"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse row" id="navbarSupportedContent">
+        <ul class="navbar-nav px-2">
+          <li class="nav-item">
+            <RouterLink
+              :to="{ name: 'home' }"
+              class="nav-link"
+              :class="{ active: route.name === 'home' }"
+            >
+              <i class="fa fa-files-o me-1" aria-hidden="true"></i>
+              IP addresses
+            </RouterLink>
+          </li>
+          <li class="nav-item">
+            <RouterLink
+              :to="{ name: 'ip_subnet_landing' }"
+              class="nav-link"
+              :class="{ active: route.name === 'ip_subnet_landing' }"
+            >
+              <i class="fa fa-bar-chart me-1" aria-hidden="true"></i>
+              IP subnets
+            </RouterLink>
+          </li>
+        </ul>
+      </div>
     </div>
   </nav>
 </template>

--- a/frontend/src/components/ProgressBar.vue
+++ b/frontend/src/components/ProgressBar.vue
@@ -1,0 +1,13 @@
+<script setup>
+defineProps(['progress'])
+</script>
+
+<template>
+  <div class="progress">
+    <div
+      class="progress-bar progress-bar-striped progress-bar-animated"
+      role="progressbar"
+      :style="{ width: `${progress}%` }"
+    ></div>
+  </div>
+</template>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import IPSubnetView from '../views/IPSubnetView.vue'
 import IPView from '../views/IPView.vue'
 
 const router = createRouter({
@@ -14,6 +15,11 @@ const router = createRouter({
       path: '/ip/:eid',
       name: 'ip',
       component: IPView,
+    },
+    {
+      path: '/ip_subnet/:ip/:prefix',
+      name: 'ip_subnet',
+      component: IPSubnetView,
     },
   ],
 })

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import IPSubnetLandingView from '../views/IPSubnetLandingView.vue'
 import IPSubnetView from '../views/IPSubnetView.vue'
 import IPView from '../views/IPView.vue'
 
@@ -15,6 +16,11 @@ const router = createRouter({
       path: '/ip/:eid',
       name: 'ip',
       component: IPView,
+    },
+    {
+      path: '/ip_subnet',
+      name: 'ip_subnet_landing',
+      component: IPSubnetLandingView,
     },
     {
       path: '/ip_subnet/:ip/:prefix',

--- a/frontend/src/templates/EntityDetailTemplate.vue
+++ b/frontend/src/templates/EntityDetailTemplate.vue
@@ -1,0 +1,133 @@
+<script setup>
+import { computed, inject, onMounted, ref } from 'vue'
+
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+dayjs.extend(utc)
+
+import SnapshotsTimePickerUrlSync from '@/components/SnapshotsTimePickerUrlSync.vue'
+
+const getData = inject('getData')
+
+const props = defineProps({
+  etype: {
+    type: String,
+    required: true,
+  },
+  eid: {
+    type: String,
+    required: true,
+  },
+})
+
+const empty = ref(false)
+const loaded = ref(false)
+const timePickerState = ref({
+  from: null,
+  to: null,
+  picked: null,
+  latest: null,
+  range: null,
+  resampleUnitCount: null,
+  resampleUnit: null,
+})
+
+const masterRecord = ref({})
+const snapshots = ref([])
+
+// Picked snapshot is either:
+// - latest one if `timePickerState.latest == true`
+// - the last one before midpoint of the selected interval otherwise
+//   (midpoint is `timePickerState.picked`)
+const pickedSnapshot = computed(() => {
+  if (snapshots.value.length > 0) {
+    if (timePickerState.value.latest) {
+      // Select last (latest) one
+      return snapshots.value[snapshots.value.length - 1]
+    } else {
+      // Find "midpoint"
+      let midpointSnapshot = null
+      let minTsDiff = Infinity
+      for (let i = 0; i < snapshots.value.length; i++) {
+        let snapshotTs = dayjs(snapshots.value[i]._time_created).millisecond(0).second(0)
+        let tsDiff = dayjs(timePickerState.value.picked).diff(snapshotTs)
+        if (tsDiff >= 0 && tsDiff < minTsDiff) {
+          minTsDiff = tsDiff
+          midpointSnapshot = snapshots.value[i]
+        }
+      }
+      return midpointSnapshot
+    }
+  } else {
+    return null
+  }
+})
+
+// Shortcut for picked snapshot timestamp
+const pickedSnapshotTs = computed(() => {
+  return dayjs.utc(pickedSnapshot.value?._time_created).local()
+})
+
+/**
+ * Loads data
+ */
+async function load() {
+  const data = await getData(`/entity/${props.etype}/${props.eid}`, {
+    params: {
+      date_from: timePickerState.value.from,
+      date_to: timePickerState.value.to,
+    },
+  })
+
+  masterRecord.value = data.master_record
+  snapshots.value = data.snapshots
+  empty.value = data.empty
+}
+
+/**
+ * Hook to update `timePickerState` value and reload data
+ */
+async function updateTimePickerState(newTimePickerState) {
+  timePickerState.value = newTimePickerState
+  await load()
+}
+
+onMounted(async () => {
+  await load()
+  loaded.value = true
+})
+</script>
+
+<template>
+  <main class="py-4">
+    <div class="container">
+      <div class="row mb-5">
+        <div class="col col-lg-7 title">
+          <slot
+            name="header"
+            :master-record="masterRecord"
+            :snapshots="snapshots"
+            :picked-snapshot="pickedSnapshot"
+            :picked-snapshot-ts="pickedSnapshotTs"
+            :time-picker-state="timePickerState"
+          ></slot>
+        </div>
+        <div class="col col-lg-5">
+          <SnapshotsTimePickerUrlSync @update:timePickerState="updateTimePickerState" />
+        </div>
+      </div>
+
+      <div v-if="empty" class="alert alert-info">No data for selected datetime in DP³</div>
+      <div v-else-if="loaded">
+        <slot
+          :master-record="masterRecord"
+          :snapshots="snapshots"
+          :picked-snapshot="pickedSnapshot"
+          :picked-snapshot-ts="pickedSnapshotTs"
+          :time-picker-state="timePickerState"
+        ></slot>
+      </div>
+      <div v-else class="spinner-border"></div>
+    </div>
+  </main>
+</template>

--- a/frontend/src/utils/commonCharts.js
+++ b/frontend/src/utils/commonCharts.js
@@ -1,6 +1,6 @@
 // Common charts options and functions
 
-import { dateCeil } from './datetime'
+import { dateFloor } from './datetime'
 
 /**
  * Chart.js options for the X axis
@@ -77,7 +77,7 @@ export function resampleTimedData(data, dtKey, unitCount, unit, reduceFn) {
 
   // Split data into buckets
   for (const item of data) {
-    const bucketKey = dateCeil(item[dtKey], unitCount, unit).getTime()
+    const bucketKey = dateFloor(item[dtKey], unitCount, unit).getTime()
     if (!buckets.has(bucketKey)) {
       buckets.set(bucketKey, [])
     }

--- a/frontend/src/utils/commonCharts.js
+++ b/frontend/src/utils/commonCharts.js
@@ -72,7 +72,7 @@ export function resampleTimedData(data, dtKey, unitCount, unit, reduceFn) {
     return []
   }
 
-  // Map to guarantee insertion order
+  // Map instead of object to allow for `Date` keys
   let buckets = new Map()
 
   // Split data into buckets
@@ -90,5 +90,7 @@ export function resampleTimedData(data, dtKey, unitCount, unit, reduceFn) {
     let bucketDt = new Date(key)
     result.push(...reduceFn(bucket, bucketDt).map((item) => ({ [dtKey]: bucketDt, ...item })))
   }
-  return result
+
+  // Ensure correct order of buckets
+  return result.sort((a, b) => a[dtKey] - b[dtKey])
 }

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -3,17 +3,17 @@
 import dayjs from 'dayjs'
 
 /**
- * Day.js macro to ceil a date to a specified unit
+ * Day.js macro to floor a date to a specified unit
  *
- * @param {Date} date Date to ceil
- * @param {Number} unitCount Number of `unit` to ceil to
- * @param {String} unit Unit to ceil to (e.g. 'minute', 'hour')
- * @returns {Date} Ceiled date
+ * @param {Date} date Date to floor
+ * @param {Number} unitCount Number of `unit` to floor to
+ * @param {String} unit Unit to floor to (e.g. 'minute', 'hour')
+ * @returns {Date} floored date
  */
-export function dateCeil(date, unitCount, unit) {
+export function dateFloor(date, unitCount, unit) {
   const inst = dayjs(date)
   return inst
-    .add(unitCount - (inst.get(unit) % unitCount), unit)
+    .subtract(inst.get(unit) % unitCount, unit)
     .startOf(unit)
     .toDate()
 }

--- a/frontend/src/views/IPSubnetLandingView.vue
+++ b/frontend/src/views/IPSubnetLandingView.vue
@@ -1,0 +1,29 @@
+<!--
+IP subnet landing page
+
+This view serves as a landing page for IP subnets.
+-->
+
+<script setup>
+import IPSubnetRedirectPicker from '@/components/IPSubnetRedirectPicker.vue'
+</script>
+
+<template>
+  <main class="py-4">
+    <div class="container">
+      <h1 class="h2">IP subnets</h1>
+      <div class="card my-4">
+        <div class="card-body">
+          <h5 class="card-title">IPv4</h5>
+          <IPSubnetRedirectPicker
+            :isIPv4="true"
+            routeName="ip_subnet"
+            :minPrefix="16"
+            :maxPrefix="32"
+            :defaultPrefix="24"
+          />
+        </div>
+      </div>
+    </div>
+  </main>
+</template>

--- a/frontend/src/views/IPSubnetView.vue
+++ b/frontend/src/views/IPSubnetView.vue
@@ -45,6 +45,10 @@ const addressCount = computed(() => {
   if (subnetInvalid.value) {
     return 0
   }
+  if (subnet.value.bitmask >= 31) {
+    // Special case for /31 and /32 due to RFC 3021
+    return subnet.value.size
+  }
   return subnet.value.size - 2
 })
 

--- a/frontend/src/views/IPSubnetView.vue
+++ b/frontend/src/views/IPSubnetView.vue
@@ -1,0 +1,191 @@
+<script setup>
+import { computed, inject, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { Netmask } from 'netmask'
+
+import ActivityTimeline from '@/components/ActivityTimeline.vue'
+import ProgressBar from '@/components/ProgressBar.vue'
+import SnapshotsTimePickerUrlSync from '@/components/SnapshotsTimePickerUrlSync.vue'
+
+// Number of IP addresses loaded in parallel
+const BATCH_SIZE = 32
+
+const getData = inject('getData')
+const route = useRoute()
+
+// Parse subnet
+const subnetInvalid = ref(false)
+let _subnet = null
+try {
+  _subnet = new Netmask(`${route.params.ip}/${route.params.prefix}`)
+} catch {
+  subnetInvalid.value = true
+}
+const subnet = ref(_subnet)
+
+// Primitive mutex
+const loading = ref(false)
+
+const timePickerState = ref({
+  from: null,
+  to: null,
+  picked: null,
+  latest: null,
+  range: null,
+  resampleUnitCount: null,
+  resampleUnit: null,
+})
+const activity = ref([])
+const addressesLoaded = ref(0)
+
+/**
+ * Number of addresses in subnet
+ */
+const addressCount = computed(() => {
+  if (subnetInvalid.value) {
+    return 0
+  }
+  return subnet.value.size - 2
+})
+
+/**
+ * Load progress percentage
+ */
+const loadProgress = computed(() => {
+  if (subnetInvalid.value) {
+    return 0
+  }
+  return (addressesLoaded.value / addressCount.value) * 100
+})
+
+/**
+ * Loads data for single IP adress
+ * @param address IP address
+ */
+async function loadAddress(address) {
+  const data = await getData(`/entity/ip/${address}/master`, {
+    params: {
+      date_from: timePickerState.value.from,
+      date_to: timePickerState.value.to,
+    },
+  })
+
+  if (data?.activity) {
+    activity.value = activity.value.concat(data.activity)
+  }
+}
+
+/**
+ * Loads data for batch of IP addresses
+ *
+ * All data is loaded in parallel.
+ *
+ * @param addresses Array of addresses to load
+ */
+async function loadBatch(addresses) {
+  const dataPromises = []
+
+  // Iterate over all IPs in subnet
+  addresses.forEach((ip) => {
+    // Push promise
+    dataPromises.push(loadAddress(ip))
+  })
+
+  // Await all promises
+  await Promise.all(dataPromises)
+}
+
+/**
+ * Loads all data
+ *
+ * Subnet is divided into batches of `BATCH_SIZE` addresses. Batches are loaded
+ * sequentially, but all addresses in a batch are loaded in parallel.
+ */
+async function load() {
+  if (subnetInvalid.value) {
+    return
+  }
+
+  // Prevent multiple loadings at the same time
+  while (loading.value) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  loading.value = true
+
+  // Reset activity
+  activity.value = []
+  addressesLoaded.value = 0
+
+  // Generate list of all addresses in subnet
+  let addresses = []
+  subnet.value.forEach((ip) => {
+    addresses.push(ip)
+  })
+
+  // Load data in batches
+  for (let i = 0; i < addresses.length; i += BATCH_SIZE) {
+    const batch = addresses.slice(i, i + BATCH_SIZE)
+
+    // Load batch
+    await loadBatch(batch)
+
+    // Update addresses loaded
+    addressesLoaded.value += batch.length
+  }
+
+  loading.value = false
+}
+
+/**
+ * Hook to update `timePickerState` value and reload data
+ */
+async function updateTimePickerState(newTimePickerState) {
+  timePickerState.value = newTimePickerState
+  await load()
+}
+</script>
+
+<template>
+  <main class="py-4">
+    <div class="container">
+      <div v-if="subnetInvalid" class="alert alert-danger">
+        Invalid subnet <code>{{ $route.params.ip }}/{{ $route.params.prefix }}</code>
+      </div>
+      <div v-else>
+        <div class="row mb-5">
+          <div class="col col-lg-7 title">
+            <h4>IP subnet</h4>
+            <h1 class="h2 fw-bold">{{ subnet.base }}/{{ subnet.bitmask }}</h1>
+            <div class="h5 text-muted">
+              <span
+                >{{ subnet.first }} &ndash; {{ subnet.last }} ({{ addressCount }}
+                {{ addressCount == 1 ? 'address' : 'addresses' }})</span
+              >
+            </div>
+          </div>
+          <div class="col col-lg-5">
+            <SnapshotsTimePickerUrlSync @update:timePickerState="updateTimePickerState" />
+          </div>
+        </div>
+
+        <div>
+          <h4 class="my-3">
+            <div class="d-flex align-items-center">
+              <span>Activity</span>
+              <ProgressBar v-if="loadProgress < 100" :progress="loadProgress" class="w-100 ms-3" />
+            </div>
+          </h4>
+          <ActivityTimeline
+            v-if="activity.length > 0 || loading"
+            :activity="activity"
+            :time-picker-state="timePickerState"
+            :picked-snapshot-ts="new Date(0)"
+            :resample-unit-count="timePickerState.resampleUnitCount"
+            :resample-unit="timePickerState.resampleUnit"
+          />
+          <div v-else class="alert alert-info">No data</div>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>

--- a/frontend/src/views/IPSubnetView.vue
+++ b/frontend/src/views/IPSubnetView.vue
@@ -116,6 +116,9 @@ async function load() {
   }
   loading.value = true
 
+  // Store current route
+  const loadingRoute = route.fullPath
+
   // Reset activity
   activity.value = []
   addressesLoaded.value = 0
@@ -128,6 +131,11 @@ async function load() {
 
   // Load data in batches
   for (let i = 0; i < addresses.length; i += BATCH_SIZE) {
+    if (route.fullPath !== loadingRoute) {
+      // Route has changed, stop loading new batches
+      break
+    }
+
     const batch = addresses.slice(i, i + BATCH_SIZE)
 
     // Load batch

--- a/frontend/src/views/IPView.vue
+++ b/frontend/src/views/IPView.vue
@@ -1,69 +1,11 @@
 <script setup>
-import { computed, inject, onMounted, ref } from 'vue'
-import { useRoute } from 'vue-router'
-
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-dayjs.extend(utc)
-
 import ActivityClassBadge from '@/components/ActivityClassBadge.vue'
 import ActivityTimeline from '@/components/ActivityTimeline.vue'
+import EntityDetailTemplate from '@/templates/EntityDetailTemplate.vue'
 import ObservationsTimeline from '@/components/ObservationsTimeline.vue'
 import OpenResolverBadge from '@/components/OpenResolverBadge.vue'
 import SnapshotsTimePickerHistoryPermalinkButton from '@/components/SnapshotsTimePickerHistoryPermalinkButton.vue'
 import SnapshotsTimePickerLatestDataPermalinkButton from '@/components/SnapshotsTimePickerLatestDataPermalinkButton.vue'
-import SnapshotsTimePickerUrlSync from '@/components/SnapshotsTimePickerUrlSync.vue'
-
-const getData = inject('getData')
-const route = useRoute()
-
-const empty = ref(false)
-const loaded = ref(false)
-const timePickerState = ref({
-  from: null,
-  to: null,
-  picked: null,
-  latest: null,
-  range: null,
-  resampleUnitCount: null,
-  resampleUnit: null,
-})
-
-const masterRecord = ref({})
-const snapshots = ref([])
-
-// Picked snapshot is either:
-// - latest one if `timePickerState.latest == true`
-// - the last one before midpoint of the selected interval otherwise
-//   (midpoint is `timePickerState.picked`)
-const pickedSnapshot = computed(() => {
-  if (snapshots.value.length > 0) {
-    if (timePickerState.value.latest) {
-      // Select last (latest) one
-      return snapshots.value[snapshots.value.length - 1]
-    } else {
-      // Find "midpoint"
-      let midpointSnapshot = null
-      let minTsDiff = Infinity
-      for (let i = 0; i < snapshots.value.length; i++) {
-        let snapshotTs = dayjs(snapshots.value[i]._time_created).millisecond(0).second(0)
-        let tsDiff = dayjs(timePickerState.value.picked).diff(snapshotTs)
-        if (tsDiff >= 0 && tsDiff < minTsDiff) {
-          minTsDiff = tsDiff
-          midpointSnapshot = snapshots.value[i]
-        }
-      }
-      return midpointSnapshot
-    }
-  } else {
-    return null
-  }
-})
-
-// Shortcut for picked snapshot timestamp
-const pickedSnapshotTs = computed(() => {
-  return dayjs.utc(pickedSnapshot.value?._time_created).local()
-})
 
 /**
  * Stringifies recog-attribute value
@@ -100,240 +42,202 @@ function stringifyRecogValue(v) {
 
   return `${service} @ ${os}`
 }
-
-/**
- * Loads data
- */
-async function load() {
-  // Load IP detail
-  const data = await getData('/entity/ip/' + route.params.eid, {
-    params: {
-      date_from: timePickerState.value.from,
-      date_to: timePickerState.value.to,
-    },
-  })
-
-  masterRecord.value = data.master_record
-  snapshots.value = data.snapshots
-  empty.value = data.empty
-}
-
-/**
- * Hook to update `timePickerState` value and reload data
- */
-async function updateTimePickerState(newTimePickerState) {
-  timePickerState.value = newTimePickerState
-  await load()
-}
-
-onMounted(async () => {
-  await load()
-  loaded.value = true
-})
 </script>
 
 <template>
-  <main class="py-4">
-    <div class="container">
-      <div class="row mb-5">
-        <div class="col col-lg-7 title">
-          <h4>IP detail</h4>
-          <h1 class="h2 fw-bold">{{ $route.params.eid }}</h1>
-          <div class="h3 row g-2">
-            <div class="col col-auto" v-if="pickedSnapshot?.hostname">
-              <span class="badge text-bg-secondary me-2 mb-1">
-                {{ pickedSnapshot?.hostname }}
-              </span>
-              <ActivityClassBadge :value="pickedSnapshot?.activity_class" class="me-2 mb-1" />
-              <OpenResolverBadge :value="pickedSnapshot?.open_resolver" class="me-2 mb-1" />
-            </div>
-          </div>
-        </div>
-        <div class="col col-lg-5">
-          <SnapshotsTimePickerUrlSync @update:timePickerState="updateTimePickerState" />
+  <EntityDetailTemplate etype="ip" :eid="$route.params.eid">
+    <template #header="{ pickedSnapshot }">
+      <h4>IP detail</h4>
+      <h1 class="h2 fw-bold">{{ $route.params.eid }}</h1>
+      <div class="h3 row g-2">
+        <div class="col col-auto" v-if="pickedSnapshot?.hostname">
+          <span class="badge text-bg-secondary me-2 mb-1">
+            {{ pickedSnapshot?.hostname }}
+          </span>
+          <ActivityClassBadge :value="pickedSnapshot?.activity_class" class="me-2 mb-1" />
+          <OpenResolverBadge :value="pickedSnapshot?.open_resolver" class="me-2 mb-1" />
         </div>
       </div>
+    </template>
 
-      <div v-if="empty" class="alert alert-info">No data for selected datetime in DP³</div>
-      <div v-else-if="loaded">
-        <div>
-          <h4 class="my-3">
-            <span>Activity</span>
-            <VTooltip class="d-inline-block ms-2 fs-5">
-              <i class="fa fa-info text-secondary"></i>
-              <template #popper>
-                Permalink to this section is identical to the history permalink (below).
-              </template>
-            </VTooltip>
-          </h4>
-          <ActivityTimeline
-            v-if="masterRecord.activity && masterRecord.activity.length > 0"
-            :activity="masterRecord.activity"
-            :time-picker-state="timePickerState"
-            :picked-snapshot-ts="pickedSnapshotTs.toDate()"
-            :resample-unit-count="timePickerState.resampleUnitCount"
-            :resample-unit="timePickerState.resampleUnit"
-          />
-          <div v-else class="alert alert-info">No data</div>
-        </div>
+    <template
+      #default="{ masterRecord, snapshots, pickedSnapshot, pickedSnapshotTs, timePickerState }"
+    >
+      <div>
+        <h4 class="my-3">
+          <span>Activity</span>
+          <VTooltip class="d-inline-block ms-2 fs-5">
+            <i class="fa fa-info text-secondary"></i>
+            <template #popper>
+              Permalink to this section is identical to the history permalink (below).
+            </template>
+          </VTooltip>
+        </h4>
+        <ActivityTimeline
+          v-if="masterRecord.activity && masterRecord.activity.length > 0"
+          :activity="masterRecord.activity"
+          :time-picker-state="timePickerState"
+          :picked-snapshot-ts="pickedSnapshotTs.toDate()"
+          :resample-unit-count="timePickerState.resampleUnitCount"
+          :resample-unit="timePickerState.resampleUnit"
+        />
+        <div v-else class="alert alert-info">No data</div>
+      </div>
 
-        <div>
-          <h4 class="mt-4 mb-3 d-flex align-items-center flex-wrap">
-            <span v-if="timePickerState.latest">Latest data</span>
-            <span v-else>Snapshot</span>
-            <div class="d-inline-block ms-2 fs-5">
-              <span class="badge rounded-pill border snapshot-date-badge">
-                <i class="fa fa-clock-o me-2"></i>{{ pickedSnapshotTs.format('DD.MM. HH:mm') }}
-              </span>
-            </div>
-            <VTooltip>
-              <SnapshotsTimePickerLatestDataPermalinkButton
-                v-if="timePickerState.latest"
-                class="btn-sm ms-2"
-                :time-picker-state="timePickerState"
-              />
-              <template #popper>Permalink to displayed latest data</template>
-            </VTooltip>
-          </h4>
-          <div v-if="pickedSnapshot" class="row">
-            <div class="col col-md-4">
-              <h6>
-                Open ports
-                <VTooltip class="d-inline-block ms-2">
-                  <i class="fa fa-info text-secondary"></i>
-                  <template #popper>
-                    Open TCP ports, based on observation of sucessfully established connections.
-                    <br />
-                    Note that ports which no one connected to (or scanned) recently are not visible
-                    this way.
-                  </template>
-                </VTooltip>
-              </h6>
-              <div v-if="(pickedSnapshot?.open_ports || []).length > 0">
-                <div
-                  v-for="(port, i) in pickedSnapshot?.open_ports.sort((a, b) => a - b)"
-                  v-bind:key="i"
-                  class="mb-2"
-                >
-                  <span class="badge bg-light text-dark fs-6">{{ port }}</span>
-                  <span class="opacity-50 ms-1">
-                    ({{ Math.round(100 * pickedSnapshot['open_ports#c'][i]) }} % confidence)
-                  </span>
-                </div>
+      <div>
+        <h4 class="mt-4 mb-3 d-flex align-items-center flex-wrap">
+          <span v-if="timePickerState.latest">Latest data</span>
+          <span v-else>Snapshot</span>
+          <div class="d-inline-block ms-2 fs-5">
+            <span class="badge rounded-pill border snapshot-date-badge">
+              <i class="fa fa-clock-o me-2"></i>{{ pickedSnapshotTs.format('DD.MM. HH:mm') }}
+            </span>
+          </div>
+          <VTooltip>
+            <SnapshotsTimePickerLatestDataPermalinkButton
+              v-if="timePickerState.latest"
+              class="btn-sm ms-2"
+              :time-picker-state="timePickerState"
+            />
+            <template #popper>Permalink to displayed latest data</template>
+          </VTooltip>
+        </h4>
+        <div v-if="pickedSnapshot" class="row">
+          <div class="col col-md-4">
+            <h6>
+              Open ports
+              <VTooltip class="d-inline-block ms-2">
+                <i class="fa fa-info text-secondary"></i>
+                <template #popper>
+                  Open TCP ports, based on observation of sucessfully established connections.
+                  <br />
+                  Note that ports which no one connected to (or scanned) recently are not visible
+                  this way.
+                </template>
+              </VTooltip>
+            </h6>
+            <div v-if="(pickedSnapshot?.open_ports || []).length > 0">
+              <div
+                v-for="(port, i) in pickedSnapshot?.open_ports.sort((a, b) => a - b)"
+                v-bind:key="i"
+                class="mb-2"
+              >
+                <span class="badge bg-light text-dark fs-6">{{ port }}</span>
+                <span class="opacity-50 ms-1">
+                  ({{ Math.round(100 * pickedSnapshot['open_ports#c'][i]) }} % confidence)
+                </span>
               </div>
-              <div v-else class="alert alert-info">No data</div>
             </div>
-            <div class="col col-md-4">
-              <h6>
-                SSH details
-                <VTooltip class="d-inline-block ms-2">
-                  <i class="fa fa-info text-secondary"></i>
-                  <template #popper>
-                    Information extracted from SSH banners sent by this IP (using Recog pattern
-                    database).
-                  </template>
-                </VTooltip>
-              </h6>
-              <pre v-if="pickedSnapshot?.recog_ssh">{{
-                JSON.stringify(pickedSnapshot?.recog_ssh, null, 2)
-              }}</pre>
-              <div v-else class="alert alert-info">No data</div>
-            </div>
-            <div class="col col-md-4">
-              <h6>
-                SMTP details
-                <VTooltip class="d-inline-block ms-2">
-                  <i class="fa fa-info text-secondary"></i>
-                  <template #popper>
-                    Information extracted from SMTP banners sent by this IP (using Recog pattern
-                    database)
-                  </template>
-                </VTooltip>
-              </h6>
-              <pre v-if="pickedSnapshot?.recog_smtp">{{
-                JSON.stringify(pickedSnapshot?.recog_smtp, null, 2)
-              }}</pre>
-              <div v-else class="alert alert-info">No data</div>
-            </div>
+            <div v-else class="alert alert-info">No data</div>
           </div>
-          <div v-else class="alert alert-info">No data in picked snapshot</div>
-        </div>
-
-        <div>
-          <h4 class="mt-4 mb-3">
-            <span>History</span>
-            <VTooltip class="d-inline-block">
-              <SnapshotsTimePickerHistoryPermalinkButton
-                v-if="timePickerState.latest"
-                class="btn-sm ms-2"
-                :time-picker-state="timePickerState"
-              />
-              <template #popper>Permalink to displayed history and activity charts</template>
-            </VTooltip>
-          </h4>
-          <div v-if="snapshots.length > 0">
-            <div class="mb-3">
-              <h6>Open ports</h6>
-              <ObservationsTimeline
-                id="open_ports"
-                :snapshots="snapshots"
-                :time-picker-state="timePickerState"
-                :picked-snapshot-ts="pickedSnapshotTs.toDate()"
-                :resample-unit-count="timePickerState.resampleUnitCount"
-                :resample-unit="timePickerState.resampleUnit"
-                :isArrayType="true"
-              />
-            </div>
-            <div class="mb-3">
-              <h6>
-                SSH details
-                <VTooltip class="d-inline-block ms-2">
-                  <i class="fa fa-info text-secondary"></i>
-                  <template #popper>
-                    Service and operating system identifiers parsed from recog SSH attribute values.
-                  </template>
-                </VTooltip>
-              </h6>
-              <ObservationsTimeline
-                id="recog_ssh"
-                :snapshots="snapshots"
-                :time-picker-state="timePickerState"
-                :picked-snapshot-ts="pickedSnapshotTs.toDate()"
-                :resample-unit-count="timePickerState.resampleUnitCount"
-                :resample-unit="timePickerState.resampleUnit"
-                :isArrayType="true"
-                :valueMapper="stringifyRecogValue"
-              />
-            </div>
-            <div class="mb-3">
-              <h6>
-                SMTP details
-                <VTooltip class="d-inline-block ms-2">
-                  <i class="fa fa-info text-secondary"></i>
-                  <template #popper>
-                    Service and operating system identifiers parsed from recog SMTP attribute
-                    values.
-                  </template>
-                </VTooltip>
-              </h6>
-              <ObservationsTimeline
-                id="recog_smtp"
-                :snapshots="snapshots"
-                :time-picker-state="timePickerState"
-                :picked-snapshot-ts="pickedSnapshotTs.toDate()"
-                :resample-unit-count="timePickerState.resampleUnitCount"
-                :resample-unit="timePickerState.resampleUnit"
-                :isArrayType="true"
-                :valueMapper="stringifyRecogValue"
-              />
-            </div>
+          <div class="col col-md-4">
+            <h6>
+              SSH details
+              <VTooltip class="d-inline-block ms-2">
+                <i class="fa fa-info text-secondary"></i>
+                <template #popper>
+                  Information extracted from SSH banners sent by this IP (using Recog pattern
+                  database).
+                </template>
+              </VTooltip>
+            </h6>
+            <pre v-if="pickedSnapshot?.recog_ssh">{{
+              JSON.stringify(pickedSnapshot?.recog_ssh, null, 2)
+            }}</pre>
+            <div v-else class="alert alert-info">No data</div>
           </div>
-          <div v-else class="alert alert-info">No snapshots</div>
+          <div class="col col-md-4">
+            <h6>
+              SMTP details
+              <VTooltip class="d-inline-block ms-2">
+                <i class="fa fa-info text-secondary"></i>
+                <template #popper>
+                  Information extracted from SMTP banners sent by this IP (using Recog pattern
+                  database)
+                </template>
+              </VTooltip>
+            </h6>
+            <pre v-if="pickedSnapshot?.recog_smtp">{{
+              JSON.stringify(pickedSnapshot?.recog_smtp, null, 2)
+            }}</pre>
+            <div v-else class="alert alert-info">No data</div>
+          </div>
         </div>
+        <div v-else class="alert alert-info">No data in picked snapshot</div>
       </div>
-      <div v-else class="spinner-border"></div>
-    </div>
-  </main>
+
+      <div>
+        <h4 class="mt-4 mb-3">
+          <span>History</span>
+          <VTooltip class="d-inline-block">
+            <SnapshotsTimePickerHistoryPermalinkButton
+              v-if="timePickerState.latest"
+              class="btn-sm ms-2"
+              :time-picker-state="timePickerState"
+            />
+            <template #popper>Permalink to displayed history and activity charts</template>
+          </VTooltip>
+        </h4>
+        <div v-if="snapshots.length > 0">
+          <div class="mb-3">
+            <h6>Open ports</h6>
+            <ObservationsTimeline
+              id="open_ports"
+              :snapshots="snapshots"
+              :time-picker-state="timePickerState"
+              :picked-snapshot-ts="pickedSnapshotTs.toDate()"
+              :resample-unit-count="timePickerState.resampleUnitCount"
+              :resample-unit="timePickerState.resampleUnit"
+              :isArrayType="true"
+            />
+          </div>
+          <div class="mb-3">
+            <h6>
+              SSH details
+              <VTooltip class="d-inline-block ms-2">
+                <i class="fa fa-info text-secondary"></i>
+                <template #popper>
+                  Service and operating system identifiers parsed from recog SSH attribute values.
+                </template>
+              </VTooltip>
+            </h6>
+            <ObservationsTimeline
+              id="recog_ssh"
+              :snapshots="snapshots"
+              :time-picker-state="timePickerState"
+              :picked-snapshot-ts="pickedSnapshotTs.toDate()"
+              :resample-unit-count="timePickerState.resampleUnitCount"
+              :resample-unit="timePickerState.resampleUnit"
+              :isArrayType="true"
+              :valueMapper="stringifyRecogValue"
+            />
+          </div>
+          <div class="mb-3">
+            <h6>
+              SMTP details
+              <VTooltip class="d-inline-block ms-2">
+                <i class="fa fa-info text-secondary"></i>
+                <template #popper>
+                  Service and operating system identifiers parsed from recog SMTP attribute values.
+                </template>
+              </VTooltip>
+            </h6>
+            <ObservationsTimeline
+              id="recog_smtp"
+              :snapshots="snapshots"
+              :time-picker-state="timePickerState"
+              :picked-snapshot-ts="pickedSnapshotTs.toDate()"
+              :resample-unit-count="timePickerState.resampleUnitCount"
+              :resample-unit="timePickerState.resampleUnit"
+              :isArrayType="true"
+              :valueMapper="stringifyRecogValue"
+            />
+          </div>
+        </div>
+        <div v-else class="alert alert-info">No snapshots</div>
+      </div>
+    </template>
+  </EntityDetailTemplate>
 </template>
 
 <style lang="css" scoped>


### PR DESCRIPTION
Displays only aggregated IP activity chart. As there's no support for subnet aggregation in DP3 (it can't be precalculated generically), frontend makes one request for master record of each IP address in subnet. This can potentially cause DoS on huge subnets if not handled correctly. Thus, requests are split into batches of 32 IPs which are fetched in parallel, while batches are processed sequentially. This approach enables us to "animate" data being "loaded" into the chart which seems user-friendly. I consider it a good tradeoff between speed, resources requirements and user experience.

There's a new dependency for a small library `netmask` to simplify IP-subnet calculations and bit manipulations.

New landing page for navigation to desired IP subnet was also added.