### PR TITLE
fix(frontend): optionally add empty buckets to resampled data

### DIFF
--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -1,6 +1,9 @@
 // Date and time manipulation utilities
 
 import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+
+dayjs.extend(duration)
 
 /**
  * Day.js macro to floor a date to a specified unit
@@ -8,7 +11,7 @@ import dayjs from 'dayjs'
  * @param {Date} date Date to floor
  * @param {Number} unitCount Number of `unit` to floor to
  * @param {String} unit Unit to floor to (e.g. 'minute', 'hour')
- * @returns {Date} floored date
+ * @returns {Date} Floored date
  */
 export function dateFloor(date, unitCount, unit) {
   const inst = dayjs(date)
@@ -16,4 +19,15 @@ export function dateFloor(date, unitCount, unit) {
     .subtract(inst.get(unit) % unitCount, unit)
     .startOf(unit)
     .toDate()
+}
+
+/**
+ * Macro to get the duration in milliseconds of a specified unit
+ *
+ * @param {Number} unitCount Number of `unit` to floor to
+ * @param {String} unit Unit to floor to (e.g. 'minute', 'hour')
+ * @returns {Number} Duration in milliseconds
+ */
+export function durationMs(unitCount, unit) {
+  return dayjs.duration(unitCount, unit).asMilliseconds()
 }


### PR DESCRIPTION
This corrects IP activity charts when there's no data in that moment by filling empty spaces with zero counters.