### PR TITLE
feat(frontend/activity_timeline): add legend

### DIFF
--- a/frontend/src/components/ActivityTimeline.vue
+++ b/frontend/src/components/ActivityTimeline.vue
@@ -63,6 +63,7 @@ const chartOptions = computed(() => {
     scales: {
       x: scaleXOptions,
       packets: {
+        display: 'auto',
         ticks: {
           callback: (v) => `${v} ${CHART_UNITS[0]}`,
           color: CHART_COLORS[0],
@@ -72,6 +73,7 @@ const chartOptions = computed(() => {
         min: 0,
       },
       flows: {
+        display: 'auto',
         ticks: {
           callback: (v) => `${v} ${CHART_UNITS[1]}`,
           color: CHART_COLORS[1],
@@ -81,6 +83,7 @@ const chartOptions = computed(() => {
         min: 0,
       },
       bytes: {
+        display: 'auto',
         ticks: {
           callback: (v) => `${v} ${CHART_UNITS[2]}`,
           color: CHART_COLORS[2],
@@ -91,7 +94,10 @@ const chartOptions = computed(() => {
       },
     },
     plugins: {
-      legend: false,
+      legend: {
+        display: true,
+        position: 'top',
+      },
       tooltip: {
         callbacks: {
           label: (item) => {


### PR DESCRIPTION
Adds legend with possibility to toggle individual axes/datasets (bytes, packets and flows).