### PR TITLE
Fix and rename IP activity classifier

### DIFF
--- a/dp3_server/config/processing_core.yml
+++ b/dp3_server/config/processing_core.yml
@@ -30,6 +30,6 @@ modules_dir: "../modules"
 # extension must be used!
 enabled_modules:
   - "dns_open_resolver"
-  - "ip_activity"
+  - "ip_activity_classifier"
   - "ip_filter"
   - "ip_to_dns_hostname"

--- a/dp3_server/modules/ip_activity_classifier.py
+++ b/dp3_server/modules/ip_activity_classifier.py
@@ -17,7 +17,7 @@ class IPActivityClassifier(BaseModule):
     def processing_function(
         self, eid: str, dp: DataPointTimeseriesBase
     ) -> List[DataPointTask]:
-        avg_bytes_per_time_step = sum(dp.v.bytes) / len(dp.v.bytes)
+        avg_bytes_per_time_step = sum(dp.v.out_bytes) / len(dp.v.out_bytes)
 
         act_class = self.ip_act(avg_bytes_per_time_step)
 

--- a/dp3_server/modules/ip_activity_classifier.py
+++ b/dp3_server/modules/ip_activity_classifier.py
@@ -7,12 +7,16 @@ from dp3.common.datapoint import DataPointTimeseriesBase
 from dp3.common.task import DataPointTask
 
 
-class IPactivity(BaseModule):
-    def __init__(self, platform_config: PlatformConfig, _, registrar: CallbackRegistrar):
+class IPActivityClassifier(BaseModule):
+    def __init__(
+        self, platform_config: PlatformConfig, _, registrar: CallbackRegistrar
+    ):
         super().__init__(platform_config, {}, registrar)
         registrar.register_on_new_attr_hook(self.processing_function, "ip", "activity")
 
-    def processing_function(self, eid: str, dp: DataPointTimeseriesBase) -> List[DataPointTask]:
+    def processing_function(
+        self, eid: str, dp: DataPointTimeseriesBase
+    ) -> List[DataPointTask]:
         avg_bytes_per_time_step = sum(dp.v.bytes) / len(dp.v.bytes)
 
         act_class = self.ip_act(avg_bytes_per_time_step)
@@ -27,7 +31,7 @@ class IPactivity(BaseModule):
                         "etype": "ip",
                         "eid": eid,
                         "attr": "activity_class",
-                        "src": "secondary/ip_activity",
+                        "src": "secondary/ip_activity_classifier",
                         "v": act_class,
                     }
                 ],


### PR DESCRIPTION
Renames IP activity secondary module to IP activity classifier to prevent misunderstandings and name conflicts, as there's also the IP activity primary module in the system.

Also fixes a bug - IP activity classifier has not been migrated to the new data model of the ip/activity attribute introduced in https://github.com/CESNET/Pandda-ADiCT/commit/51c59a75a816cceacb57801e48cdad8aabf304e3. `out_bytes` should be used instead of `bytes`.