### PR TITLE
build(dp3): pin version to 0.9

### DIFF
--- a/dp3_server/requirements.txt
+++ b/dp3_server/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/CESNET/dp3.git#egg=dp-cubed
+dp-cubed[dev,deploy,scripts]~=0.9.0
 requests
 setuptools>=57.0.0
 dnspython~=2.6.1


### PR DESCRIPTION
DP3 version installed using Ansible playbooks is set to 0.9. Use the same version for development as well to prevent problems with different behaviour.

https://github.com/CESNET/Pandda-Playbooks/blob/8b816089d160befe2b43965bb604dcaeb1ecc671/ansible/roles/dp3/tasks/dp3/install_dp3.yml#L13